### PR TITLE
make guest feedback visible

### DIFF
--- a/.changeset/hot-peas-learn.md
+++ b/.changeset/hot-peas-learn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-entity-feedback-backend': minor
+---
+
+Entity ratings and responses provided by users not in the catalog will now be visible to the guest user that submitted it and the owner of the entity

--- a/plugins/entity-feedback-backend/package.json
+++ b/plugins/entity-feedback-backend/package.json
@@ -47,6 +47,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/supertest": "^2.0.12",
+    "jest-when": "^3.6.0",
     "msw": "^1.0.0",
     "supertest": "^6.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6524,6 +6524,7 @@ __metadata:
     "@types/supertest": ^2.0.12
     express: ^4.18.1
     express-promise-router: ^4.1.0
+    jest-when: ^3.6.0
     knex: ^2.0.0
     msw: ^1.0.0
     node-fetch: ^2.6.7
@@ -29925,7 +29926,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-when@npm:^3.1.0":
+"jest-when@npm:^3.1.0, jest-when@npm:^3.6.0":
   version: 3.6.0
   resolution: "jest-when@npm:3.6.0"
   peerDependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Feedback submitted for an entity by a user that isn't in the catalog will now appear for the user that submitted it and any owners of the entity.
Before, any feedback submitted by a user that wasn't in the catalog would appear in the aggregates for the entity but to the user that submitted it it would appear as though their feedback wasn't recorded. The response also would not appear in the feedback section for the entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
